### PR TITLE
Feat: network graph, further LDK fixes

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -81,6 +81,7 @@ interface Node {
 	sequence<PaymentDetails> list_payments();
 	sequence<PeerDetails> list_peers();
 	sequence<ChannelDetails> list_channels();
+	NetworkGraph network_graph();
 	[Throws=NodeError]
 	string sign_message([ByRef]sequence<u8> msg);
 	boolean verify_signature([ByRef]sequence<u8> msg, [ByRef]string sig, [ByRef]PublicKey pkey);
@@ -148,6 +149,7 @@ enum NodeError {
 	"InvalidSocketAddress",
 	"InvalidPublicKey",
 	"InvalidSecretKey",
+	"InvalidNodeId",
 	"InvalidPaymentId",
 	"InvalidPaymentHash",
 	"InvalidPaymentPreimage",
@@ -380,6 +382,46 @@ dictionary TlvEntry {
 	sequence<u8> value;
 };
 
+interface NetworkGraph {
+	sequence<u64> list_channels();
+	ChannelInfo? channel(u64 short_channel_id);
+	sequence<NodeId> list_nodes();
+	NodeInfo? node([ByRef]NodeId node_id);
+};
+
+dictionary ChannelInfo {
+	NodeId node_one;
+	ChannelUpdateInfo? one_to_two;
+	NodeId node_two;
+	ChannelUpdateInfo? two_to_one;
+	u64? capacity_sats;
+};
+
+dictionary ChannelUpdateInfo {
+	u32 last_update;
+	boolean enabled;
+	u16 cltv_expiry_delta;
+	u64 htlc_minimum_msat;
+	u64 htlc_maximum_msat;
+	RoutingFees fees;
+};
+
+dictionary RoutingFees {
+	u32 base_msat;
+	u32 proportional_millionths;
+};
+
+dictionary NodeInfo {
+	sequence<u64> channels;
+	NodeAnnouncementInfo? announcement_info;
+};
+
+dictionary NodeAnnouncementInfo {
+	u32 last_update;
+	string alias;
+	sequence<SocketAddress> addresses;
+};
+
 [Custom]
 typedef string Txid;
 
@@ -391,6 +433,9 @@ typedef string SocketAddress;
 
 [Custom]
 typedef string PublicKey;
+
+[Custom]
+typedef string NodeId;
 
 [Custom]
 typedef string Address;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -15,7 +15,7 @@ use crate::payment::store::PaymentStore;
 use crate::peer_store::PeerStore;
 use crate::tx_broadcaster::TransactionBroadcaster;
 use crate::types::{
-	ChainMonitor, ChannelManager, DynStore, GossipSync, KeysManager, MessageRouter, NetworkGraph,
+	ChainMonitor, ChannelManager, DynStore, GossipSync, Graph, KeysManager, MessageRouter,
 	OnionMessenger, PeerManager,
 };
 use crate::wallet::Wallet;
@@ -633,7 +633,7 @@ fn build_with_store_internal(
 			Ok(graph) => Arc::new(graph),
 			Err(e) => {
 				if e.kind() == std::io::ErrorKind::NotFound {
-					Arc::new(NetworkGraph::new(config.network.into(), Arc::clone(&logger)))
+					Arc::new(Graph::new(config.network.into(), Arc::clone(&logger)))
 				} else {
 					return Err(BuildError::ReadFailed);
 				}

--- a/src/config.rs
+++ b/src/config.rs
@@ -46,7 +46,7 @@ pub(crate) const WALLET_SYNC_INTERVAL_MINIMUM_SECS: u64 = 10;
 pub(crate) const BDK_WALLET_SYNC_TIMEOUT_SECS: u64 = 90;
 
 // The timeout after which we abort a wallet syncing operation.
-pub(crate) const LDK_WALLET_SYNC_TIMEOUT_SECS: u64 = 90; // 10
+pub(crate) const LDK_WALLET_SYNC_TIMEOUT_SECS: u64 = 90; // 30
 
 // The timeout after which we abort a fee rate cache update operation.
 pub(crate) const FEE_RATE_CACHE_UPDATE_TIMEOUT_SECS: u64 = 5;

--- a/src/error.rs
+++ b/src/error.rs
@@ -53,6 +53,8 @@ pub enum Error {
 	InvalidPublicKey,
 	/// The given secret key is invalid.
 	InvalidSecretKey,
+	/// The given node id is invalid.
+	InvalidNodeId,
 	/// The given payment id is invalid.
 	InvalidPaymentId,
 	/// The given payment hash is invalid.
@@ -115,6 +117,7 @@ impl fmt::Display for Error {
 			Self::InvalidSocketAddress => write!(f, "The given network address is invalid."),
 			Self::InvalidPublicKey => write!(f, "The given public key is invalid."),
 			Self::InvalidSecretKey => write!(f, "The given secret key is invalid."),
+			Self::InvalidNodeId => write!(f, "The given node id is invalid."),
 			Self::InvalidPaymentId => write!(f, "The given payment id is invalid."),
 			Self::InvalidPaymentHash => write!(f, "The given payment hash is invalid."),
 			Self::InvalidPaymentPreimage => write!(f, "The given payment preimage is invalid."),

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,6 +1,6 @@
 use crate::types::{DynStore, Sweeper, Wallet};
 use crate::{
-	hex_utils, BumpTransactionEventHandler, ChannelManager, Config, Error, NetworkGraph, PeerInfo,
+	hex_utils, BumpTransactionEventHandler, ChannelManager, Config, Error, Graph, PeerInfo,
 	PeerStore, UserChannelId,
 };
 
@@ -319,7 +319,7 @@ where
 	bump_tx_event_handler: Arc<BumpTransactionEventHandler>,
 	channel_manager: Arc<ChannelManager>,
 	output_sweeper: Arc<Sweeper>,
-	network_graph: Arc<NetworkGraph>,
+	network_graph: Arc<Graph>,
 	payment_store: Arc<PaymentStore<L>>,
 	peer_store: Arc<PeerStore<L>>,
 	runtime: Arc<RwLock<Option<tokio::runtime::Runtime>>>,
@@ -335,7 +335,7 @@ where
 		event_queue: Arc<EventQueue<L>>, wallet: Arc<Wallet>,
 		bump_tx_event_handler: Arc<BumpTransactionEventHandler>,
 		channel_manager: Arc<ChannelManager>, output_sweeper: Arc<Sweeper>,
-		network_graph: Arc<NetworkGraph>, payment_store: Arc<PaymentStore<L>>,
+		network_graph: Arc<Graph>, payment_store: Arc<PaymentStore<L>>,
 		peer_store: Arc<PeerStore<L>>, runtime: Arc<RwLock<Option<tokio::runtime::Runtime>>>,
 		logger: L, config: Arc<Config>,
 	) -> Self {

--- a/src/gossip.rs
+++ b/src/gossip.rs
@@ -1,6 +1,6 @@
 use crate::config::RGS_SYNC_TIMEOUT_SECS;
 use crate::logger::{log_trace, FilesystemLogger, Logger};
-use crate::types::{GossipSync, NetworkGraph, P2PGossipSync, RapidGossipSync};
+use crate::types::{GossipSync, Graph, P2PGossipSync, RapidGossipSync};
 use crate::Error;
 
 use lightning::routing::utxo::UtxoLookup;
@@ -22,7 +22,7 @@ pub(crate) enum GossipSource {
 }
 
 impl GossipSource {
-	pub fn new_p2p(network_graph: Arc<NetworkGraph>, logger: Arc<FilesystemLogger>) -> Self {
+	pub fn new_p2p(network_graph: Arc<Graph>, logger: Arc<FilesystemLogger>) -> Self {
 		let gossip_sync = Arc::new(P2PGossipSync::new(
 			network_graph,
 			None::<Arc<dyn UtxoLookup + Send + Sync>>,
@@ -32,7 +32,7 @@ impl GossipSource {
 	}
 
 	pub fn new_rgs(
-		server_url: String, latest_sync_timestamp: u32, network_graph: Arc<NetworkGraph>,
+		server_url: String, latest_sync_timestamp: u32, network_graph: Arc<Graph>,
 		logger: Arc<FilesystemLogger>,
 	) -> Self {
 		let gossip_sync = Arc::new(RapidGossipSync::new(network_graph, Arc::clone(&logger)));

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,0 +1,166 @@
+//! Objects for querying the network graph.
+
+use crate::types::Graph;
+
+use lightning::routing::gossip::NodeId;
+
+#[cfg(feature = "uniffi")]
+use lightning::ln::msgs::SocketAddress;
+#[cfg(feature = "uniffi")]
+use lightning::routing::gossip::RoutingFees;
+
+#[cfg(not(feature = "uniffi"))]
+use lightning::routing::gossip::{ChannelInfo, NodeInfo};
+
+use std::sync::Arc;
+
+/// Represents the network as nodes and channels between them.
+pub struct NetworkGraph {
+	inner: Arc<Graph>,
+}
+
+impl NetworkGraph {
+	pub(crate) fn new(inner: Arc<Graph>) -> Self {
+		Self { inner }
+	}
+
+	/// Returns the list of channels in the graph
+	pub fn list_channels(&self) -> Vec<u64> {
+		self.inner.read_only().channels().unordered_keys().map(|c| *c).collect()
+	}
+
+	/// Returns information on a channel with the given id.
+	pub fn channel(&self, short_channel_id: u64) -> Option<ChannelInfo> {
+		self.inner.read_only().channels().get(&short_channel_id).cloned().map(|c| c.into())
+	}
+
+	/// Returns the list of nodes in the graph
+	pub fn list_nodes(&self) -> Vec<NodeId> {
+		self.inner.read_only().nodes().unordered_keys().map(|n| *n).collect()
+	}
+
+	/// Returns information on a node with the given id.
+	pub fn node(&self, node_id: &NodeId) -> Option<NodeInfo> {
+		self.inner.read_only().nodes().get(node_id).cloned().map(|n| n.into())
+	}
+}
+
+/// Details about a channel (both directions).
+///
+/// Received within a channel announcement.
+///
+/// This is a simplified version of LDK's `ChannelInfo` for bindings.
+#[cfg(feature = "uniffi")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelInfo {
+	/// Source node of the first direction of a channel
+	pub node_one: NodeId,
+	/// Details about the first direction of a channel
+	pub one_to_two: Option<ChannelUpdateInfo>,
+	/// Source node of the second direction of a channel
+	pub node_two: NodeId,
+	/// Details about the second direction of a channel
+	pub two_to_one: Option<ChannelUpdateInfo>,
+	/// The channel capacity as seen on-chain, if chain lookup is available.
+	pub capacity_sats: Option<u64>,
+}
+
+#[cfg(feature = "uniffi")]
+impl From<lightning::routing::gossip::ChannelInfo> for ChannelInfo {
+	fn from(value: lightning::routing::gossip::ChannelInfo) -> Self {
+		Self {
+			node_one: value.node_one,
+			one_to_two: value.one_to_two.map(|u| u.into()),
+			node_two: value.node_two,
+			two_to_one: value.two_to_one.map(|u| u.into()),
+			capacity_sats: value.capacity_sats,
+		}
+	}
+}
+
+/// Details about one direction of a channel as received within a `ChannelUpdate`.
+///
+/// This is a simplified version of LDK's `ChannelUpdateInfo` for bindings.
+#[cfg(feature = "uniffi")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ChannelUpdateInfo {
+	/// When the last update to the channel direction was issued.
+	/// Value is opaque, as set in the announcement.
+	pub last_update: u32,
+	/// Whether the channel can be currently used for payments (in this one direction).
+	pub enabled: bool,
+	/// The difference in CLTV values that you must have when routing through this channel.
+	pub cltv_expiry_delta: u16,
+	/// The minimum value, which must be relayed to the next hop via the channel
+	pub htlc_minimum_msat: u64,
+	/// The maximum value which may be relayed to the next hop via the channel.
+	pub htlc_maximum_msat: u64,
+	/// Fees charged when the channel is used for routing
+	pub fees: RoutingFees,
+}
+
+#[cfg(feature = "uniffi")]
+impl From<lightning::routing::gossip::ChannelUpdateInfo> for ChannelUpdateInfo {
+	fn from(value: lightning::routing::gossip::ChannelUpdateInfo) -> Self {
+		Self {
+			last_update: value.last_update,
+			enabled: value.enabled,
+			cltv_expiry_delta: value.cltv_expiry_delta,
+			htlc_minimum_msat: value.htlc_minimum_msat,
+			htlc_maximum_msat: value.htlc_maximum_msat,
+			fees: value.fees,
+		}
+	}
+}
+
+/// Details about a node in the network, known from the network announcement.
+///
+/// This is a simplified version of LDK's `NodeInfo` for bindings.
+#[cfg(feature = "uniffi")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeInfo {
+	/// All valid channels a node has announced
+	pub channels: Vec<u64>,
+	/// More information about a node from node_announcement.
+	/// Optional because we store a Node entry after learning about it from
+	/// a channel announcement, but before receiving a node announcement.
+	pub announcement_info: Option<NodeAnnouncementInfo>,
+}
+
+#[cfg(feature = "uniffi")]
+impl From<lightning::routing::gossip::NodeInfo> for NodeInfo {
+	fn from(value: lightning::routing::gossip::NodeInfo) -> Self {
+		Self {
+			channels: value.channels,
+			announcement_info: value.announcement_info.map(|a| a.into()),
+		}
+	}
+}
+
+/// Information received in the latest node_announcement from this node.
+///
+/// This is a simplified version of LDK's `NodeAnnouncementInfo` for bindings.
+#[cfg(feature = "uniffi")]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct NodeAnnouncementInfo {
+	/// When the last known update to the node state was issued.
+	/// Value is opaque, as set in the announcement.
+	pub last_update: u32,
+	/// Moniker assigned to the node.
+	/// May be invalid or malicious (eg control chars),
+	/// should not be exposed to the user.
+	pub alias: String,
+	/// List of addresses on which this node is reachable
+	pub addresses: Vec<SocketAddress>,
+}
+
+#[cfg(feature = "uniffi")]
+impl From<lightning::routing::gossip::NodeAnnouncementInfo> for NodeAnnouncementInfo {
+	fn from(value: lightning::routing::gossip::NodeAnnouncementInfo) -> Self {
+		Self {
+			last_update: value.last_update,
+			alias: value.alias.to_string(),
+			addresses: value.addresses().iter().cloned().collect(),
+		}
+	}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ mod error;
 mod event;
 mod fee_estimator;
 mod gossip;
+pub mod graph;
 mod hex_utils;
 pub mod io;
 mod liquidity;
@@ -128,13 +129,14 @@ use config::{
 use connection::ConnectionManager;
 use event::{EventHandler, EventQueue};
 use gossip::GossipSource;
+use graph::NetworkGraph;
 use liquidity::LiquiditySource;
 use payment::store::PaymentStore;
 use payment::{Bolt11Payment, OnchainPayment, PaymentDetails, SpontaneousPayment};
 use peer_store::{PeerInfo, PeerStore};
 use types::{
 	Broadcaster, BumpTransactionEventHandler, ChainMonitor, ChannelManager, DynStore, FeeEstimator,
-	KeysManager, NetworkGraph, PeerManager, Router, Scorer, Sweeper, Wallet,
+	Graph, KeysManager, PeerManager, Router, Scorer, Sweeper, Wallet,
 };
 pub use types::{ChannelDetails, ChannelType, PeerDetails, TlvEntry, UserChannelId};
 
@@ -184,7 +186,7 @@ pub struct Node {
 	peer_manager: Arc<PeerManager>,
 	connection_manager: Arc<ConnectionManager<Arc<FilesystemLogger>>>,
 	keys_manager: Arc<KeysManager>,
-	network_graph: Arc<NetworkGraph>,
+	network_graph: Arc<Graph>,
 	gossip_source: Arc<GossipSource>,
 	liquidity_source: Option<Arc<LiquiditySource<Arc<FilesystemLogger>>>>,
 	kv_store: Arc<DynStore>,
@@ -1472,6 +1474,18 @@ impl Node {
 		}
 
 		peers
+	}
+
+	/// Returns a handler allowing to query the network graph.
+	#[cfg(not(feature = "uniffi"))]
+	pub fn network_graph(&self) -> NetworkGraph {
+		NetworkGraph::new(Arc::clone(&self.network_graph))
+	}
+
+	/// Returns a handler allowing to query the network graph.
+	#[cfg(feature = "uniffi")]
+	pub fn network_graph(&self) -> Arc<NetworkGraph> {
+		Arc::new(NetworkGraph::new(Arc::clone(&self.network_graph)))
 	}
 
 	/// Creates a digital ECDSA signature of a message with the node's secret key.

--- a/src/types.rs
+++ b/src/types.rs
@@ -80,31 +80,28 @@ pub(crate) type KeysManager = crate::wallet::WalletKeysManager<
 >;
 
 pub(crate) type Router = DefaultRouter<
-	Arc<NetworkGraph>,
+	Arc<Graph>,
 	Arc<FilesystemLogger>,
 	Arc<KeysManager>,
 	Arc<Mutex<Scorer>>,
 	ProbabilisticScoringFeeParameters,
 	Scorer,
 >;
-pub(crate) type Scorer = ProbabilisticScorer<Arc<NetworkGraph>, Arc<FilesystemLogger>>;
+pub(crate) type Scorer = ProbabilisticScorer<Arc<Graph>, Arc<FilesystemLogger>>;
 
-pub(crate) type NetworkGraph = gossip::NetworkGraph<Arc<FilesystemLogger>>;
+pub(crate) type Graph = gossip::NetworkGraph<Arc<FilesystemLogger>>;
 
 pub(crate) type UtxoLookup = dyn lightning::routing::utxo::UtxoLookup + Send + Sync;
 
-pub(crate) type P2PGossipSync = lightning::routing::gossip::P2PGossipSync<
-	Arc<NetworkGraph>,
-	Arc<UtxoLookup>,
-	Arc<FilesystemLogger>,
->;
+pub(crate) type P2PGossipSync =
+	lightning::routing::gossip::P2PGossipSync<Arc<Graph>, Arc<UtxoLookup>, Arc<FilesystemLogger>>;
 pub(crate) type RapidGossipSync =
-	lightning_rapid_gossip_sync::RapidGossipSync<Arc<NetworkGraph>, Arc<FilesystemLogger>>;
+	lightning_rapid_gossip_sync::RapidGossipSync<Arc<Graph>, Arc<FilesystemLogger>>;
 
 pub(crate) type GossipSync = lightning_background_processor::GossipSync<
 	Arc<P2PGossipSync>,
 	Arc<RapidGossipSync>,
-	Arc<NetworkGraph>,
+	Arc<Graph>,
 	Arc<UtxoLookup>,
 	Arc<FilesystemLogger>,
 >;
@@ -120,7 +117,7 @@ pub(crate) type OnionMessenger = lightning::onion_message::messenger::OnionMesse
 >;
 
 pub(crate) type MessageRouter = lightning::onion_message::messenger::DefaultMessageRouter<
-	Arc<NetworkGraph>,
+	Arc<Graph>,
 	Arc<FilesystemLogger>,
 	Arc<KeysManager>,
 >;

--- a/src/uniffi_types.rs
+++ b/src/uniffi_types.rs
@@ -1,7 +1,9 @@
+pub use crate::graph::{ChannelInfo, ChannelUpdateInfo, NodeAnnouncementInfo, NodeInfo};
 pub use crate::payment::store::{LSPFeeLimits, PaymentDirection, PaymentKind, PaymentStatus};
 
 pub use lightning::events::{ClosureReason, PaymentFailureReason};
 pub use lightning::ln::{ChannelId, PaymentHash, PaymentPreimage, PaymentSecret};
+pub use lightning::routing::gossip::{NodeId, RoutingFees};
 pub use lightning::util::string::UntrustedString;
 
 pub use lightning_invoice::Bolt11Invoice;
@@ -34,6 +36,22 @@ impl UniffiCustomTypeConverter for PublicKey {
 		}
 
 		Err(Error::InvalidPublicKey.into())
+	}
+
+	fn from_custom(obj: Self) -> Self::Builtin {
+		obj.to_string()
+	}
+}
+
+impl UniffiCustomTypeConverter for NodeId {
+	type Builtin = String;
+
+	fn into_custom(val: Self::Builtin) -> uniffi::Result<Self> {
+		if let Ok(key) = NodeId::from_str(&val) {
+			return Ok(key);
+		}
+
+		Err(Error::InvalidNodeId.into())
 	}
 
 	fn from_custom(obj: Self) -> Self::Builtin {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -3,7 +3,10 @@
 
 use ldk_node::io::sqlite_store::SqliteStore;
 use ldk_node::payment::{PaymentDirection, PaymentStatus};
-use ldk_node::{Builder, Config, Event, LogLevel, Node, NodeError, TlvEntry};
+use ldk_node::{
+	Builder, Config, Event, LightningBalance, LogLevel, Node, NodeError, PendingSweepBalance,
+	TlvEntry,
+};
 
 use lightning::ln::msgs::SocketAddress;
 use lightning::util::persist::KVStore;
@@ -169,6 +172,8 @@ pub(crate) fn random_config(anchor_channels: bool) -> Config {
 	}
 
 	config.network = Network::Regtest;
+	config.onchain_wallet_sync_interval_secs = 100000;
+	config.wallet_sync_interval_secs = 100000;
 	println!("Setting network: {}", config.network);
 
 	let rand_dir = random_storage_path();
@@ -359,7 +364,7 @@ pub fn open_channel(
 
 pub(crate) fn do_channel_full_cycle<E: ElectrumApi>(
 	node_a: TestNode, node_b: TestNode, bitcoind: &BitcoindClient, electrsd: &E, allow_0conf: bool,
-	expect_anchor_channel: bool,
+	expect_anchor_channel: bool, force_close: bool,
 ) {
 	let addr_a = node_a.onchain_payment().new_address().unwrap();
 	let addr_b = node_b.onchain_payment().new_address().unwrap();
@@ -568,8 +573,14 @@ pub(crate) fn do_channel_full_cycle<E: ElectrumApi>(
 	assert_eq!(node_b.payment(&keysend_payment_id).unwrap().direction, PaymentDirection::Inbound);
 	assert_eq!(node_b.payment(&keysend_payment_id).unwrap().amount_msat, Some(keysend_amount_msat));
 
-	println!("\nB close_channel");
-	node_b.close_channel(&user_channel_id, node_a.node_id(), false).unwrap();
+	println!("\nB close_channel (force: {})", force_close);
+	if force_close {
+		std::thread::sleep(Duration::from_secs(1));
+		node_b.close_channel(&user_channel_id, node_a.node_id(), true).unwrap();
+	} else {
+		node_b.close_channel(&user_channel_id, node_a.node_id(), false).unwrap();
+	}
+
 	expect_event!(node_a, ChannelClosed);
 	expect_event!(node_b, ChannelClosed);
 
@@ -578,6 +589,87 @@ pub(crate) fn do_channel_full_cycle<E: ElectrumApi>(
 	generate_blocks_and_wait(&bitcoind, electrsd, 1);
 	node_a.sync_wallets().unwrap();
 	node_b.sync_wallets().unwrap();
+
+	if force_close {
+		// Check node_a properly sees all balances and sweeps them.
+		assert_eq!(node_a.list_balances().lightning_balances.len(), 1);
+		match node_a.list_balances().lightning_balances[0] {
+			LightningBalance::ClaimableAwaitingConfirmations {
+				counterparty_node_id,
+				confirmation_height,
+				..
+			} => {
+				assert_eq!(counterparty_node_id, node_b.node_id());
+				let cur_height = node_a.status().current_best_block.height;
+				let blocks_to_go = confirmation_height - cur_height;
+				generate_blocks_and_wait(&bitcoind, electrsd, blocks_to_go as usize);
+				node_a.sync_wallets().unwrap();
+				node_b.sync_wallets().unwrap();
+			},
+			_ => panic!("Unexpected balance state!"),
+		}
+
+		assert!(node_a.list_balances().lightning_balances.is_empty());
+		assert_eq!(node_a.list_balances().pending_balances_from_channel_closures.len(), 1);
+		match node_a.list_balances().pending_balances_from_channel_closures[0] {
+			PendingSweepBalance::BroadcastAwaitingConfirmation { .. } => {},
+			_ => panic!("Unexpected balance state!"),
+		}
+		generate_blocks_and_wait(&bitcoind, electrsd, 1);
+		node_a.sync_wallets().unwrap();
+		node_b.sync_wallets().unwrap();
+
+		assert!(node_a.list_balances().lightning_balances.is_empty());
+		assert_eq!(node_a.list_balances().pending_balances_from_channel_closures.len(), 1);
+		match node_a.list_balances().pending_balances_from_channel_closures[0] {
+			PendingSweepBalance::AwaitingThresholdConfirmations { .. } => {},
+			_ => panic!("Unexpected balance state!"),
+		}
+		generate_blocks_and_wait(&bitcoind, electrsd, 5);
+		node_a.sync_wallets().unwrap();
+		node_b.sync_wallets().unwrap();
+
+		assert!(node_a.list_balances().lightning_balances.is_empty());
+		assert!(node_a.list_balances().pending_balances_from_channel_closures.is_empty());
+
+		// Check node_b properly sees all balances and sweeps them.
+		assert_eq!(node_b.list_balances().lightning_balances.len(), 1);
+		match node_b.list_balances().lightning_balances[0] {
+			LightningBalance::ClaimableAwaitingConfirmations {
+				counterparty_node_id,
+				confirmation_height,
+				..
+			} => {
+				assert_eq!(counterparty_node_id, node_a.node_id());
+				let cur_height = node_b.status().current_best_block.height;
+				let blocks_to_go = confirmation_height - cur_height;
+				generate_blocks_and_wait(&bitcoind, electrsd, blocks_to_go as usize);
+				node_b.sync_wallets().unwrap();
+				node_a.sync_wallets().unwrap();
+			},
+			_ => panic!("Unexpected balance state!"),
+		}
+
+		assert!(node_b.list_balances().lightning_balances.is_empty());
+		assert_eq!(node_b.list_balances().pending_balances_from_channel_closures.len(), 1);
+		match node_b.list_balances().pending_balances_from_channel_closures[0] {
+			PendingSweepBalance::BroadcastAwaitingConfirmation { .. } => {},
+			_ => panic!("Unexpected balance state!"),
+		}
+		generate_blocks_and_wait(&bitcoind, electrsd, 1);
+		node_b.sync_wallets().unwrap();
+		node_a.sync_wallets().unwrap();
+
+		assert!(node_b.list_balances().lightning_balances.is_empty());
+		assert_eq!(node_b.list_balances().pending_balances_from_channel_closures.len(), 1);
+		match node_b.list_balances().pending_balances_from_channel_closures[0] {
+			PendingSweepBalance::AwaitingThresholdConfirmations { .. } => {},
+			_ => panic!("Unexpected balance state!"),
+		}
+		generate_blocks_and_wait(&bitcoind, electrsd, 5);
+		node_b.sync_wallets().unwrap();
+		node_a.sync_wallets().unwrap();
+	}
 
 	let sum_of_all_payments_sat = (push_msat
 		+ invoice_amount_1_msat
@@ -590,11 +682,11 @@ pub(crate) fn do_channel_full_cycle<E: ElectrumApi>(
 	let node_a_lower_bound_sat = node_a_upper_bound_sat - onchain_fee_buffer_sat;
 	assert!(node_a.list_balances().spendable_onchain_balance_sats > node_a_lower_bound_sat);
 	assert!(node_a.list_balances().spendable_onchain_balance_sats < node_a_upper_bound_sat);
-	let expected_final_amount_node_b_sat = premine_amount_sat + sum_of_all_payments_sat;
-	assert_eq!(
-		node_b.list_balances().spendable_onchain_balance_sats,
-		expected_final_amount_node_b_sat
-	);
+
+	let node_b_upper_bound_sat = premine_amount_sat + sum_of_all_payments_sat;
+	let node_b_lower_bound_sat = node_b_upper_bound_sat - onchain_fee_buffer_sat;
+	assert!(node_b.list_balances().spendable_onchain_balance_sats > node_b_lower_bound_sat);
+	assert!(node_b.list_balances().spendable_onchain_balance_sats <= node_b_upper_bound_sat);
 
 	// Check we handled all events
 	assert_eq!(node_a.next_event(), None);

--- a/tests/integration_tests_rust.rs
+++ b/tests/integration_tests_rust.rs
@@ -19,21 +19,28 @@ use std::sync::Arc;
 fn channel_full_cycle() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let (node_a, node_b) = setup_two_nodes(&electrsd, false, true);
-	do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, false, true);
+	do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, false, true, false);
+}
+
+#[test]
+fn channel_full_cycle_force_close() {
+	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
+	let (node_a, node_b) = setup_two_nodes(&electrsd, false, true);
+	do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, false, true, true);
 }
 
 #[test]
 fn channel_full_cycle_0conf() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let (node_a, node_b) = setup_two_nodes(&electrsd, true, true);
-	do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, true, true)
+	do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, true, true, false)
 }
 
 #[test]
 fn channel_full_cycle_legacy_staticremotekey() {
 	let (bitcoind, electrsd) = setup_bitcoind_and_electrsd();
 	let (node_a, node_b) = setup_two_nodes(&electrsd, false, false);
-	do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, false, false);
+	do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, false, false, false);
 }
 
 #[test]

--- a/tests/integration_tests_vss.rs
+++ b/tests/integration_tests_vss.rs
@@ -24,5 +24,13 @@ fn channel_full_cycle_with_vss_store() {
 	let node_b = builder_b.build_with_vss_store(vss_base_url, "node_2_store".to_string()).unwrap();
 	node_b.start().unwrap();
 
-	common::do_channel_full_cycle(node_a, node_b, &bitcoind.client, &electrsd.client, false, true);
+	common::do_channel_full_cycle(
+		node_a,
+		node_b,
+		&bitcoind.client,
+		&electrsd.client,
+		false,
+		true,
+		false,
+	);
 }


### PR DESCRIPTION
LDK now exposes the network graph which can be queried. Also, a few extra LDK fixes from tnull's active branches (fix signing transaction to bump anchor amounts on close channel, reusing last unused address).