### PR TITLE
fix: remove esplora client timeout

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,6 +1,7 @@
 use crate::config::{
 	default_user_config, Config, BDK_CLIENT_CONCURRENCY, BDK_CLIENT_STOP_GAP,
-	DEFAULT_ESPLORA_CLIENT_TIMEOUT_SECS, DEFAULT_ESPLORA_SERVER_URL, WALLET_KEYS_SEED_LEN,
+	/*DEFAULT_ESPLORA_CLIENT_TIMEOUT_SECS, */ DEFAULT_ESPLORA_SERVER_URL,
+	WALLET_KEYS_SEED_LEN,
 };
 use crate::connection::ConnectionManager;
 use crate::event::EventQueue;
@@ -558,8 +559,9 @@ fn build_with_store_internal(
 
 	let (blockchain, tx_sync, tx_broadcaster, fee_estimator) = match chain_data_source_config {
 		Some(ChainDataSourceConfig::Esplora(server_url)) => {
-			let mut client_builder = esplora_client::Builder::new(&server_url.clone());
-			client_builder = client_builder.timeout(DEFAULT_ESPLORA_CLIENT_TIMEOUT_SECS);
+			let /*mut */client_builder = esplora_client::Builder::new(&server_url.clone());
+			// Alby - disable timeout due to possible blocking behaviour
+			// client_builder = client_builder.timeout(DEFAULT_ESPLORA_CLIENT_TIMEOUT_SECS);
 			let esplora_client = client_builder.build_async().unwrap();
 			let tx_sync = Arc::new(EsploraSyncClient::from_client(
 				esplora_client.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,7 +32,7 @@ pub(crate) const BDK_CLIENT_CONCURRENCY: u8 = 4;
 pub(crate) const DEFAULT_ESPLORA_SERVER_URL: &str = "https://blockstream.info/api";
 
 // The default Esplora client timeout we're using.
-pub(crate) const DEFAULT_ESPLORA_CLIENT_TIMEOUT_SECS: u64 = 10;
+// pub(crate) const DEFAULT_ESPLORA_CLIENT_TIMEOUT_SECS: u64 = 10;
 
 // The timeout after which we abandon retrying failed payments.
 pub(crate) const LDK_PAYMENT_RETRY_TIMEOUT: Duration = Duration::from_secs(50); // (10);


### PR DESCRIPTION
suggested by tnull to remove possible timeout errors due to using a blocking sync