### PR TITLE
Account for `check-cfg`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,3 +87,13 @@ rpath = true
 
 [profile.dev]
 panic = "abort"
+
+[lints.rust.unexpected_cfgs]
+level = "forbid"
+# When adding a new cfg attribute, ensure that it is added to this list.
+check-cfg = [
+	"cfg(vss)",
+	"cfg(vss_test)",
+	"cfg(ldk_bench)",
+	"cfg(tokio_unstable)",
+]


### PR DESCRIPTION
Recently, Rust 1.80 introduced automatic checking of `cfg` flags (see https://blog.rust-lang.org/2024/05/06/check-cfg.html). Here, we add all custom `cfg`s to the expected list