### PR TITLE
feat: migrate from sqlite to VSS (WIP)

### DIFF
--- a/bindings/ldk_node.udl
+++ b/bindings/ldk_node.udl
@@ -52,6 +52,7 @@ interface Builder {
 	Node build_with_fs_store();
 	void restore_encoded_channel_monitors(sequence<KeyValue> monitors);
 	void reset_state(ResetState what);
+	void migrate_storage(MigrateStorage what);
 	[Throws=BuildError]
 	Node build_with_vss_store(string vss_url, string store_id, string lnurl_auth_server_url, record<string, string> fixed_headers);
 	[Throws=BuildError]
@@ -650,4 +651,9 @@ enum ResetState {
  	"Scorer",
  	"NetworkGraph",
  	"All",
+ };
+
+enum MigrateStorage {
+ 	"VSS",
+ 	// "Sqlite",
  };

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -586,18 +586,18 @@ impl NodeBuilder {
 					secondary_namespace,
 					key
 				);
-				let channel_monitor_value =
+				let value =
 					from_store.read(primary_namespace, secondary_namespace, key).map_err(|e| {
 						log_error!(logger, "Failed to fetch value: {}", e);
 						BuildError::KVStoreSetupFailed
 					})?;
 				// write value to new store
-				vss_store
-					.write(primary_namespace, secondary_namespace, key, &channel_monitor_value)
-					.map_err(|e| {
+				vss_store.write(primary_namespace, secondary_namespace, key, &value).map_err(
+					|e| {
 						log_error!(logger, "Failed to migrate value: {}", e);
 						BuildError::KVStoreSetupFailed
-					})?;
+					},
+				)?;
 				Ok(())
 			};
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -26,13 +26,15 @@ use crate::peer_store::PeerStore;
 use crate::tx_broadcaster::TransactionBroadcaster;
 use crate::types::{
 	ChainMonitor, ChannelManager, DynStore, GossipSync, Graph, KeyValue, KeysManager,
-	MessageRouter, OnionMessenger, PeerManager, ResetState,
+	MessageRouter, MigrateStorage, OnionMessenger, PeerManager, ResetState,
 };
 use crate::wallet::persist::KVStoreWalletPersister;
 use crate::wallet::Wallet;
 use crate::{io, NodeMetrics};
 use crate::{LogLevel, Node};
+use lightning::util::persist::KVStore;
 
+use chrono::Local;
 use lightning::chain::{chainmonitor, BestBlock, Watch};
 use lightning::io::Cursor;
 use lightning::ln::channelmanager::{self, ChainParameters, ChannelManagerReadArgs};
@@ -48,6 +50,7 @@ use lightning::sign::EntropySource;
 use lightning::util::persist::{
 	read_channel_monitors, CHANNEL_MANAGER_PERSISTENCE_KEY,
 	CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE, CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+	CHANNEL_MONITOR_PERSISTENCE_PRIMARY_NAMESPACE, CHANNEL_MONITOR_PERSISTENCE_SECONDARY_NAMESPACE,
 	NETWORK_GRAPH_PERSISTENCE_KEY, NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE,
 	NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE, SCORER_PERSISTENCE_KEY,
 	SCORER_PERSISTENCE_PRIMARY_NAMESPACE, SCORER_PERSISTENCE_SECONDARY_NAMESPACE,
@@ -75,7 +78,7 @@ use std::convert::TryInto;
 use std::default::Default;
 use std::fmt;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, RwLock};
 use std::time::SystemTime;
@@ -190,6 +193,7 @@ pub struct NodeBuilder {
 	liquidity_source_config: Option<LiquiditySourceConfig>,
 	monitors_to_restore: Option<Vec<KeyValue>>,
 	reset_state: Option<ResetState>,
+	migrate_storage: Option<MigrateStorage>,
 }
 
 impl NodeBuilder {
@@ -207,6 +211,7 @@ impl NodeBuilder {
 		let liquidity_source_config = None;
 		let monitors_to_restore = None;
 		let reset_state = None;
+		let migrate_storage = None;
 		Self {
 			config,
 			entropy_source_config,
@@ -215,6 +220,7 @@ impl NodeBuilder {
 			liquidity_source_config,
 			monitors_to_restore,
 			reset_state,
+			migrate_storage,
 		}
 	}
 
@@ -227,6 +233,12 @@ impl NodeBuilder {
 	/// Alby: persistent state components to reset on startup.
 	pub fn reset_state(&mut self, what: ResetState) -> &mut Self {
 		self.reset_state = Some(what);
+		self
+	}
+
+	/// Alby: migrate storage on startup.
+	pub fn migrate_storage(&mut self, what: MigrateStorage) -> &mut Self {
+		self.migrate_storage = Some(what);
 		self
 	}
 
@@ -495,6 +507,40 @@ impl NodeBuilder {
 
 		let vss_seed_bytes: [u8; 32] = vss_xprv.private_key.secret_bytes();
 
+		// Alby: migrate from sqlite to VSS
+		let mut migrate_from_store = None;
+		let migrate_to_vss = match self.migrate_storage {
+			Some(MigrateStorage::VSS) => true,
+			_ => false,
+		};
+		if migrate_to_vss {
+			// rename and read existing file
+			let storage_dir_path = config.storage_dir_path.clone();
+
+			// Get the current date and time
+			let now = Local::now();
+			let timestamp = now.format("%Y%m%d_%H%M%S").to_string();
+
+			// Create a backup filename based on the current date and time
+			let backup_filename = format!("ldk_node_data_{}.sqlite", timestamp);
+			let old_file_path =
+				Path::new(storage_dir_path.as_str()).join(io::sqlite_store::SQLITE_DB_FILE_NAME);
+			let new_file_path = Path::new(storage_dir_path.as_str()).join(backup_filename.clone());
+
+			// Rename the file, so that we start fresh
+			fs::rename(&old_file_path, &new_file_path).unwrap();
+
+			// Read from the old file
+			migrate_from_store = Some(Arc::new(
+				SqliteStore::new(
+					storage_dir_path.into(),
+					Some(backup_filename),
+					Some(io::sqlite_store::KV_TABLE_NAME.to_string()),
+				)
+				.map_err(|_| BuildError::KVStoreSetupFailed)?,
+			) as Arc<DynStore>);
+		}
+
 		// Alby: use a secondary KV store for non-essential data (not needed by VSS)
 		let storage_dir_path = config.storage_dir_path.clone();
 		let secondary_kv_store = Arc::new(
@@ -512,6 +558,62 @@ impl NodeBuilder {
 				log_error!(logger, "Failed to setup VssStore: {}", e);
 				BuildError::KVStoreSetupFailed
 			})?;
+
+		if migrate_from_store.is_some() {
+			// write essential data from old store to new store
+			let from_store = migrate_from_store.unwrap();
+
+			// TODO: migrate peers (IMPORTANT otherwise channel is offline!)
+			// TODO: error handling
+			// TODO: add logging (log all keys that were migrated)
+			// TODO: cleanup the code
+			// TODO: close the DB connection
+
+			let channel_monitor_keys = from_store
+				.list(
+					CHANNEL_MONITOR_PERSISTENCE_PRIMARY_NAMESPACE,
+					CHANNEL_MONITOR_PERSISTENCE_SECONDARY_NAMESPACE,
+				)
+				.unwrap();
+
+			for key in channel_monitor_keys {
+				let channel_monitor_value = from_store
+					.read(
+						CHANNEL_MONITOR_PERSISTENCE_PRIMARY_NAMESPACE,
+						CHANNEL_MONITOR_PERSISTENCE_SECONDARY_NAMESPACE,
+						key.as_str(),
+					)
+					.unwrap();
+				// write value to new store
+				vss_store
+					.write(
+						CHANNEL_MONITOR_PERSISTENCE_PRIMARY_NAMESPACE,
+						CHANNEL_MONITOR_PERSISTENCE_SECONDARY_NAMESPACE,
+						key.as_str(),
+						&channel_monitor_value,
+					)
+					.unwrap();
+			}
+
+			// migrate channel manager
+			let channel_manager_value = from_store
+				.read(
+					CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+					CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+					CHANNEL_MANAGER_PERSISTENCE_KEY,
+				)
+				.unwrap();
+			// write value to new store
+			vss_store
+				.write(
+					CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE,
+					CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE,
+					CHANNEL_MANAGER_PERSISTENCE_KEY,
+					&channel_manager_value,
+				)
+				.unwrap();
+		}
+
 		build_with_store_internal(
 			config,
 			self.chain_data_source_config.as_ref(),
@@ -593,6 +695,11 @@ impl ArcedNodeBuilder {
 	/// Alby: persistent state components to reset on startup.
 	pub fn reset_state(&self, what: ResetState) {
 		self.inner.write().unwrap().reset_state(what);
+	}
+
+	/// Alby: migrate storage on startup.
+	pub fn migrate_storage(&self, what: MigrateStorage) {
+		self.inner.write().unwrap().migrate_storage(what);
 	}
 
 	/// Configures the [`Node`] instance to source its wallet entropy from a seed file on disk.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,13 +136,13 @@ use payment::{
 	UnifiedQrPayment,
 };
 use peer_store::{PeerInfo, PeerStore};
-#[cfg(feature = "uniffi")]
-use types::ResetState;
 use types::{
 	Broadcaster, BumpTransactionEventHandler, ChainMonitor, ChannelManager, DynStore, Graph,
 	KeysManager, OnionMessenger, PeerManager, Router, Scorer, Sweeper, Wallet,
 };
 pub use types::{ChannelDetails, ChannelType, KeyValue, PeerDetails, TlvEntry, UserChannelId};
+#[cfg(feature = "uniffi")]
+use types::{MigrateStorage, ResetState};
 
 use logger::{log_error, log_info, log_trace, FilesystemLogger, Logger};
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -415,3 +415,12 @@ pub enum ResetState {
 	/// All of the above.
 	All,
 }
+
+/// Options to migrate from one storage type to another.
+#[derive(Debug, Copy, Clone)]
+pub enum MigrateStorage {
+	/// SQLite to VSS
+	VSS,
+	// VSS to SQLite - currently unsupported
+	// Sqlite,
+}


### PR DESCRIPTION
On the hub side, I would update the Alby Account page to allow the user to manually enable VSS (currently a one-way upgrade), which would save user configs (`LdkVssEnabled=true` and `LdkMigrateStorage="VSS"`) and shut down the node, and then ask them to login. When they login, the user config entry will be checked, removed, and the migration to VSS will occur, using `builder.MigrateStorage(ldk_node.MigrateStorageVss)`. (in the same way we have methods to reset some node state right now)

How it works:
1. We rename the existing LDK-node sqlite DB as a backup file.
2. We create the VSS store, with a fresh secondary storage (a new LDK-node sqlite DB)
3. We migrate essential data from the backup file to VSS. (channel manager, channel monitors, and list of peers.)

There could be some edge cases to consider (e.g. if there are pending channel monitor updates we should not proceed with the migration), and some TODOs to address.


LDK-nodes original migration script is below, but not all the keys are needed, and I'm not sure it's 100% correct.

```
/// **Warning**: This will overwrite existing data in VSS for the node.
	pub fn migrate_data_from_fs_to_vss(
		&self, vss_url: String, store_id: String, header_provider: Arc<dyn VssHeaderProvider>,
	) -> Result<(), BuildError> {
		let logger = setup_logger(&self.config)?;

		let seed_bytes = seed_bytes_from_config(
			&self.config,
			self.entropy_source_config.as_ref(),
			Arc::clone(&logger),
		)?;

		let config = Arc::new(self.config.clone());

		let vss_xprv = derive_vss_xprv(config.clone(), &seed_bytes, Arc::clone(&logger))?;

		let vss_seed_bytes: [u8; 32] = vss_xprv.private_key.secret_bytes();

		let mut storage_dir_path: PathBuf = self.config.storage_dir_path.clone().into();
		storage_dir_path.push("fs_store");

		fs::create_dir_all(storage_dir_path.clone())
			.map_err(|_| BuildError::StoragePathAccessFailed)?;
		let fs_store = FilesystemStore::new(storage_dir_path);

		let vss_store =
			VssStore::new(vss_url, store_id, vss_seed_bytes, header_provider).map_err(|e| {
				log_error!(logger, "Failed to setup VssStore: {}", e);
				BuildError::KVStoreSetupFailed
			})?;

		let namespace_pairs = [
			(
				io::EVENT_QUEUE_PERSISTENCE_PRIMARY_NAMESPACE,
				io::EVENT_QUEUE_PERSISTENCE_SECONDARY_NAMESPACE,
			),
			(
				io::PEER_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
				io::PEER_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
			),
			(
				io::PAYMENT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
				io::PAYMENT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
			),
			(
				io::DEPRECATED_SPENDABLE_OUTPUT_INFO_PERSISTENCE_PRIMARY_NAMESPACE,
				io::DEPRECATED_SPENDABLE_OUTPUT_INFO_PERSISTENCE_SECONDARY_NAMESPACE,
			),
			(io::NODE_METRICS_PRIMARY_NAMESPACE, io::NODE_METRICS_SECONDARY_NAMESPACE),
			(
				io::BDK_WALLET_DESCRIPTOR_PRIMARY_NAMESPACE,
				io::BDK_WALLET_DESCRIPTOR_SECONDARY_NAMESPACE,
			),
			(
				io::BDK_WALLET_CHANGE_DESCRIPTOR_PRIMARY_NAMESPACE,
				io::BDK_WALLET_CHANGE_DESCRIPTOR_SECONDARY_NAMESPACE,
			),
			(io::BDK_WALLET_NETWORK_PRIMARY_NAMESPACE, io::BDK_WALLET_NETWORK_SECONDARY_NAMESPACE),
			(
				io::BDK_WALLET_LOCAL_CHAIN_PRIMARY_NAMESPACE,
				io::BDK_WALLET_LOCAL_CHAIN_SECONDARY_NAMESPACE,
			),
			(io::BDK_WALLET_TX_GRAPH_PRIMARY_NAMESPACE, io::BDK_WALLET_TX_GRAPH_PRIMARY_NAMESPACE),
			(io::BDK_WALLET_INDEXER_PRIMARY_NAMESPACE, io::BDK_WALLET_INDEXER_SECONDARY_NAMESPACE),
			(CHANNEL_MANAGER_PERSISTENCE_PRIMARY_NAMESPACE, CHANNEL_MANAGER_PERSISTENCE_SECONDARY_NAMESPACE),
			(CHANNEL_MONITOR_PERSISTENCE_PRIMARY_NAMESPACE, CHANNEL_MONITOR_PERSISTENCE_SECONDARY_NAMESPACE),
			(ARCHIVED_CHANNEL_MONITOR_PERSISTENCE_PRIMARY_NAMESPACE, ARCHIVED_CHANNEL_MONITOR_PERSISTENCE_SECONDARY_NAMESPACE),
			(NETWORK_GRAPH_PERSISTENCE_PRIMARY_NAMESPACE, NETWORK_GRAPH_PERSISTENCE_SECONDARY_NAMESPACE),
			(SCORER_PERSISTENCE_PRIMARY_NAMESPACE, SCORER_PERSISTENCE_SECONDARY_NAMESPACE),
			(OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE, OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE),
			(OUTPUT_SWEEPER_PERSISTENCE_PRIMARY_NAMESPACE, OUTPUT_SWEEPER_PERSISTENCE_SECONDARY_NAMESPACE),
		];

		Self::migrate_kvstore(
			&fs_store as &dyn KVStore,
			&vss_store as &dyn KVStore,
			&namespace_pairs,
		)
			.unwrap();

		Ok(())
	}

	fn migrate_kvstore(
		source: &dyn KVStore, dest: &dyn KVStore, namespace_pairs: &[(&str, &str)],
	) -> Result<(), std::io::Error> {
		let unique_namespace_pairs: std::collections::HashSet<(&str, &str)> =
			namespace_pairs.iter().cloned().collect();
		let unique_namespace_pairs: Vec<(&str, &str)> =
			unique_namespace_pairs.into_iter().collect();

		for &(primary_namespace, secondary_namespace) in &unique_namespace_pairs {
			let keys = source.list(primary_namespace, secondary_namespace)?;
			for key in keys {
				let value = source.read(primary_namespace, secondary_namespace, &key)?;
				dest.write(primary_namespace, secondary_namespace, &key, &value)?
			}
		}
		Ok(())
	}
```