### PR TITLE
fix: raise inbound channel size limit

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,8 @@ const DEFAULT_LDK_WALLET_SYNC_INTERVAL_SECS: u64 = 30;
 const DEFAULT_FEE_RATE_CACHE_UPDATE_INTERVAL_SECS: u64 = 60 * 10;
 const DEFAULT_PROBING_LIQUIDITY_LIMIT_MULTIPLIER: u64 = 3;
 const DEFAULT_ANCHOR_PER_CHANNEL_RESERVE_SATS: u64 = 25_000;
+// Alby: our project is well-tested and requires larger inbound channels,
+// especially for business users.
 const DEFAULT_MAX_INBOUND_CHANNEL_SIZE_SATS: u64 = 10 * 100_000_000;
 
 /// The default log level.
@@ -330,6 +332,8 @@ pub(crate) fn default_user_config(config: &Config) -> UserConfig {
 	// some of the values set here, e.g. the ChannelHandshakeConfig, meaning these default values
 	// will mostly be relevant for inbound channels.
 	let mut user_config = UserConfig::default();
+	// Alby: override LDK's default inbound channel limit to allow larger
+	// channels needed by well-tested deployments and business users.
 	user_config.channel_handshake_limits.max_funding_satoshis =
 		DEFAULT_MAX_INBOUND_CHANNEL_SIZE_SATS;
 	user_config.channel_handshake_limits.force_announced_channel_preference = false;

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ const DEFAULT_LDK_WALLET_SYNC_INTERVAL_SECS: u64 = 30;
 const DEFAULT_FEE_RATE_CACHE_UPDATE_INTERVAL_SECS: u64 = 60 * 10;
 const DEFAULT_PROBING_LIQUIDITY_LIMIT_MULTIPLIER: u64 = 3;
 const DEFAULT_ANCHOR_PER_CHANNEL_RESERVE_SATS: u64 = 25_000;
+const DEFAULT_MAX_INBOUND_CHANNEL_SIZE_SATS: u64 = 10 * 100_000_000;
 
 /// The default log level.
 pub const DEFAULT_LOG_LEVEL: LogLevel = LogLevel::Debug;
@@ -329,6 +330,8 @@ pub(crate) fn default_user_config(config: &Config) -> UserConfig {
 	// some of the values set here, e.g. the ChannelHandshakeConfig, meaning these default values
 	// will mostly be relevant for inbound channels.
 	let mut user_config = UserConfig::default();
+	user_config.channel_handshake_limits.max_funding_satoshis =
+		DEFAULT_MAX_INBOUND_CHANNEL_SIZE_SATS;
 	user_config.channel_handshake_limits.force_announced_channel_preference = false;
 	user_config.manually_accept_inbound_channels = true;
 	user_config.channel_handshake_config.negotiate_anchors_zero_fee_htlc_tx =
@@ -565,7 +568,21 @@ pub enum AsyncPaymentsRole {
 mod tests {
 	use std::str::FromStr;
 
-	use super::{may_announce_channel, AnnounceError, Config, NodeAlias, SocketAddress};
+	use super::{
+		default_user_config, may_announce_channel, AnnounceError, Config, NodeAlias, SocketAddress,
+		DEFAULT_MAX_INBOUND_CHANNEL_SIZE_SATS,
+	};
+
+	#[test]
+	fn default_user_config_allows_10_btc_inbound_channels() {
+		let node_config = Config::default();
+		let user_config = default_user_config(&node_config);
+
+		assert_eq!(
+			user_config.channel_handshake_limits.max_funding_satoshis,
+			DEFAULT_MAX_INBOUND_CHANNEL_SIZE_SATS
+		);
+	}
 
 	#[test]
 	fn node_announce_channel() {


### PR DESCRIPTION
## Summary
- Increase the default inbound channel funding limit to 10 BTC (`1_000_000_000` sats)
- Add a unit test covering the Alby default user config value

References getAlby/hub#2016.

## Test Plan
- `rustup run stable cargo fmt --check`
- `rustup run stable cargo test default_user_config_allows_10_btc_inbound_channels --lib`
- `rustup run stable cargo test node_announce_channel --lib`

Note: `cargo test ...` with Rust 1.85.0 failed on the existing trait upcasting coercion in `src/lib.rs`; the tests above pass with stable Rust 1.95.0.
